### PR TITLE
fix the go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module go-srp
+module github.com/ProtonMail/go-srp
 
 go 1.12
 
 require (
 	github.com/jameskeane/bcrypt v0.0.0-20120420032655-c3cd44c1e20f
-	golang.org/x/crypto v0.0.0-20190604143603-d3d8a14a4d4f
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/mobile v0.0.0-20190910184405-b558ed863381 // indirect
 )
 


### PR DESCRIPTION
Fix the go.mod file to have the updated version of golang.og/x/crypto.
Changed module name from go-srp to github.com/ProtonMail/go-srp.
This allows to run `go get github.com/ProtonMail/go-srp`