### PR TITLE
Windows wrapper imports with the new module name

### DIFF
--- a/windows/cshared/main.go
+++ b/windows/cshared/main.go
@@ -26,7 +26,7 @@ import "C"
 import (
 	"bytes"
 	"encoding/binary"
-	srp "go-srp" //this could hange to repo link
+	srp "github.com/ProtonMail/go-srp" //this could hange to repo link
 	"math/rand"
 )
 


### PR DESCRIPTION
In https://github.com/ProtonMail/go-srp/pull/2 , we modified the go module name from `go-srp` to `github.com/ProtonMail/go-srp`
This modifies the `main.go` file of the windows wrapper to use the updated name.