### PR TITLE
Make the authentication version number used accessible.

### DIFF
--- a/srp.go
+++ b/srp.go
@@ -60,6 +60,7 @@ type Proofs struct {
 //  * Also the data from the API called Auth. it could be match the meaning and reduce the confusion
 type Auth struct {
 	Modulus, ServerEphemeral, HashedPassword []byte
+	Version                                  int
 }
 
 // Amored pubkey for modulus verification
@@ -140,6 +141,9 @@ func NewAuth(version int, username string, password []byte, b64salt, signedModul
 		return
 	}
 
+	// Authentication version
+	data.Version = version
+
 	auth = data
 	return
 }
@@ -179,6 +183,8 @@ func NewAuthForVerifier(password []byte, signedModulus string, rawSalt []byte) (
 	if err != nil {
 		return
 	}
+	// Authentication version hardcoded
+	data.Version = 4
 	auth = data
 	return
 }


### PR DESCRIPTION
When creating an Auth struct to generate the verifier,
the version used is hardcoded to the latest version number.
But this version used was not visible to the client, and the client needed to
guess it in order to communicate it to the server.
We add the function `auth.GetVersion()` to make it accessible.