### PR TITLE
Remove the workaround with version `$2y$` of bcrypt.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,11 @@ for authentication.
 
 ### Changed
 * Changed the return type of `ECDLPChallenge` from uint64 to int64 to be supported
-by gomobile. 
+by gomobile.
+
+## Fixed
+* Use the `$2y$` version of `bcrypt` internally directly instead of using a workaround
+with `$2a$`.
 
 ## v0.0.1 (2021-09-29)
 

--- a/hash.go
+++ b/hash.go
@@ -48,12 +48,7 @@ var based64DotSlash = base64.NewEncoding("./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
 // Usage:
 //
 func bcryptHash(password []byte, encodedSalt string) (hashed []byte, err error) {
-	realSalt := []byte("$2a$10$" + encodedSalt)
-	hashed, err = bcrypt.HashBytes(password, realSalt)
-	if len(hashed) > 4 {
-		hashed = append([]byte("$2y$"), hashed[4:]...)
-	}
-	return
+	return bcrypt.HashBytes(password, []byte("$2y$10$"+encodedSalt))
 }
 
 // expandHash extends the byte data for SRP flow


### PR DESCRIPTION
Use the `$2y$` version of bcrypt directly (supported by the fork github.com/ProtonMail/bcrypt)
instead of using `$2a$` and casting it afterward.