### PR TITLE
Use github.com/ProtonMail/bcrypt directly instead of using replacement.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,10 +9,13 @@ for authentication.
 ### Changed
 * Changed the return type of `ECDLPChallenge` from uint64 to int64 to be supported
 by gomobile.
+* Use `github.com/ProtonMail/bcrypt` directly instead of relying on replace statements for 
+`github.com/jameskeane/bcrypt`.
 
 ## Fixed
 * Use the `$2y$` version of `bcrypt` internally directly instead of using a workaround
 with `$2a$`.
+
 
 ## v0.0.1 (2021-09-29)
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ Please see [LICENSE](LICENSE.txt) file for the license.
 - [Technical blog post](https://protonmail.com/blog/encrypted_email_authentication/)
 - [RFC 5054](https://datatracker.ietf.org/doc/html/rfc5054)
 
-## Replacement
-
-Make sure you replace the go module `github.com/jameskeane/bcrypt`
-with its fork `github.com/ProtonMail/bcrypt`
-
 ## .NET Wrapper
 
 The `windows` folder contains the wrapper for .net.

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
 package: srp
 import:
 - package: github.com/ProtonMail/go-crypto
-- package: github.com/jameskeane/bcrypt
+- package: github.com/ProtonMail/bcrypt

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.12
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
 	github.com/cronokirby/saferith v0.31.0
-	github.com/jameskeane/bcrypt v0.0.0-20120420032655-c3cd44c1e20f
+	github.com/ProtonMail/bcrypt v0.0.0-20210511135022-227b4adcab57
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 )
 
-replace golang.org/x/mobile => github.com/ProtonMail/go-mobile v0.0.0-20201014085805-7a2d68bf792f
-
-replace github.com/jameskeane/bcrypt => github.com/ProtonMail/bcrypt v0.0.0-20210511135022-227b4adcab57
+replace golang.org/x/mobile => github.com/ProtonMail/go-mobile v0.0.0-20201014085805-7a2d68bf792

--- a/hash.go
+++ b/hash.go
@@ -31,7 +31,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/jameskeane/bcrypt"
+	"github.com/ProtonMail/bcrypt"
 )
 
 //based64DotSlash Bcrypt uses an adapted base64 alphabet (using . instead of +, starting with ./ and with no padding).


### PR DESCRIPTION
Instead of importing github.com/jameskeane/bcrypt and replacing with the
fork in the go.mod, we import the fork directly.